### PR TITLE
Add code to create output dir if it doesn't exist

### DIFF
--- a/find-aopHSI-flightlines.R
+++ b/find-aopHSI-flightlines.R
@@ -131,6 +131,11 @@ write_shapefile_bound <- function(f, shpDir, proj4Str){
   outName <- gsub(pattern = ".h5",
                   x = basename(f),
                   replacement = "")
+  
+  # create the output directory we want to use if it doesn't yet exist
+  ifelse(!dir.exists(file.path(shpDir)), 
+	   dir.create(file.path(shpDir), showWarnings = TRUE))
+  
   writeOGR(sp.obj, 
            shpDir, #path to export to
            outName,

--- a/find-aopHSI-flightlines.R
+++ b/find-aopHSI-flightlines.R
@@ -134,7 +134,9 @@ write_shapefile_bound <- function(f, shpDir, proj4Str){
   
   # create the output directory we want to use if it doesn't yet exist
   ifelse(!dir.exists(file.path(shpDir)), 
-	   dir.create(file.path(shpDir), showWarnings = TRUE))
+         dir.create(file.path(shpDir),
+                    showWarnings = TRUE,
+                    recursive = TRUE))
   
   writeOGR(sp.obj, 
            shpDir, #path to export to


### PR DESCRIPTION
In the `write_shapefile_bound()` function, creates the output dir if it doesn't yet exist.
